### PR TITLE
Fix resque predis prefix function

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     "ext-pcntl": "*",
     "monolog/monolog": ">=1.2.0",
     "kamisama/monolog-init": ">=0.1.1",
-    "predis/predis": ">=1.1"
+    "predis/predis": "^1.1@stable"
   },
   "require-dev": {
     "phpunit/phpunit": ">=4.8 < 6.0"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "0e446646edda1c4db8282fec88208d97",
+    "content-hash": "b9b0e2ed2a72ce108404222a7421d498",
     "packages": [
         {
             "name": "kamisama/monolog-init",
@@ -1541,7 +1541,9 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {
+        "predis/predis": 0
+    },
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {

--- a/lib/Resque/Redis.php
+++ b/lib/Resque/Redis.php
@@ -14,14 +14,13 @@ if (class_exists('\Predis\Client')) {
          */
         public function __construct($host, $port, $timeout = 5, $password = null, $phpiredis = false)
         {
-            $options = [];
+            $options = ['profile' => '3.0'];
             $params = [
                 'host' => $host,
                 'port' => $port,
                 'password' => $password,
                 'read_write_timeout' => $timeout,
             ];
-
 
             if ($phpiredis) {
                 $options['connections'] = [
@@ -38,13 +37,16 @@ if (class_exists('\Predis\Client')) {
          *
          * @param string $prefix
          */
-        public function prefix($prefix)
+        public function prefix($prefix = '')
         {
-            if (strpos($prefix, ':') === false) {
-                $prefix .= ':';
+            if (!empty($prefix)) {
+                if (strpos($prefix, ':') === false) {
+                    $prefix .= ':';
+                }
+
+                $processor = new Predis\Command\Processor\KeyPrefixProcessor($prefix);
+                $this->getProfile()->setProcessor($processor);
             }
-            $prefixer = new Predis\Command\Processor\KeyPrefixProcessor($prefix);
-            $this->getOptions()->commands->setProcessor($prefixer);
         }
     }
 } elseif (class_exists('\Redis')) {

--- a/lib/Resque/Redis.php
+++ b/lib/Resque/Redis.php
@@ -14,7 +14,7 @@ if (class_exists('\Predis\Client')) {
          */
         public function __construct($host, $port, $timeout = 5, $password = null, $phpiredis = false)
         {
-            $options = ['profile' => '3.0'];
+            $options = [];
             $params = [
                 'host' => $host,
                 'port' => $port,

--- a/lib/Resque/Redis.php
+++ b/lib/Resque/Redis.php
@@ -44,7 +44,7 @@ if (class_exists('\Predis\Client')) {
                 $prefix .= ':';
             }
             $prefixer = new Predis\Command\Processor\KeyPrefixProcessor($prefix);
-            $this->getProfile()->setProcessor($prefixer);
+            $this->getOptions()->commands->setProcessor($prefixer);
         }
     }
 } elseif (class_exists('\Redis')) {

--- a/test/Resque/TestCase.php
+++ b/test/Resque/TestCase.php
@@ -9,7 +9,7 @@ class Resque_Tests_TestCase extends PHPUnit_Framework_TestCase
     {
         $config = file_get_contents(REDIS_CONF);
         preg_match('#^\s*port\s+([0-9]+)#m', $config, $matches);
-        $this->redis = new RedisApi('127.0.0.1', $matches[1]);
+        $this->redis = new Resque_Redis('127.0.0.1', $matches[1]);
         $this->redis->prefix(REDIS_NAMESPACE);
         $this->redis->select(REDIS_DATABASE);
         // Flush redis


### PR DESCRIPTION
Predis does not have a simple way to change prefix
after client instantiation. This fixes an error in that
end.